### PR TITLE
Add "Featured In" press links to about page and homepage

### DIFF
--- a/blog/content/about/index.md
+++ b/blog/content/about/index.md
@@ -31,6 +31,12 @@ I will typically write about topics I find interesting and/or esoteric bugs I've
 Thanks for stopping by, fam.
 
 
+## Featured In
+
+* [How Peloton Engineers the World's Largest Live Fitness Events on AWS](https://aws.amazon.com/blogs/industries/how-peloton-engineers-the-worlds-largest-live-fitness-events-on-aws/) - AWS for Industries Blog, Jul 2026
+* [Peloton Behind the Scenes Engineering Stops the Crashes](https://theclipout.com/peloton-behind-the-scenes-engineering/) - The Clip Out, Jul 2026
+* [Peloton's engineering team makes the case for test in production](https://www.techtarget.com/searchcloudcomputing/feature/Pelotons-engineering-team-makes-the-case-for-test-in-production) - TechTarget, Jul 2026
+
 ## Talks
 
 * [Pytennessee 2020](https://mottaquikarim.github.io/WEBSITE2/pytn/)

--- a/blog/layouts/partials/posts.html
+++ b/blog/layouts/partials/posts.html
@@ -30,6 +30,11 @@
 <a href='{{ "/tags/" | relLangURL }}{{ $taxonomyname | urlize }}'>{{ $taxonomyname }}</a>
 {{end}}
 {{ end }}
+<br>
+<strong>recently featured in: </strong>
+<a href="https://aws.amazon.com/blogs/industries/how-peloton-engineers-the-worlds-largest-live-fitness-events-on-aws/">AWS Blog</a> &middot;
+<a href="https://www.techtarget.com/searchcloudcomputing/feature/Pelotons-engineering-team-makes-the-case-for-test-in-production">TechTarget</a> &middot;
+<a href="https://theclipout.com/peloton-behind-the-scenes-engineering/">The Clip Out</a>
 
         {{/* Build the homepage entry set: posts not folded into a digest, plus digests and field guides. */}}
         {{ $standalonePosts := where (where site.RegularPages "Type" "posts") "Params.digest" nil }}


### PR DESCRIPTION
Adds links to three recent press pieces covering Peloton's test-in-production work:

- [How Peloton Engineers the World's Largest Live Fitness Events on AWS](https://aws.amazon.com/blogs/industries/how-peloton-engineers-the-worlds-largest-live-fitness-events-on-aws/) — AWS for Industries Blog, Jul 2026
- [Peloton Behind the Scenes Engineering Stops the Crashes](https://theclipout.com/peloton-behind-the-scenes-engineering/) — The Clip Out, Jul 2026
- [Peloton's engineering team makes the case for test in production](https://www.techtarget.com/searchcloudcomputing/feature/Pelotons-engineering-team-makes-the-case-for-test-in-production) — TechTarget, Jul 2026

Changes:
- **About page** (`blog/content/about/index.md`): new "Featured In" section above "Talks", same linked-list style, with outlet names and dates.
- **Homepage** (`blog/layouts/partials/posts.html`): compact "recently featured in:" strapline under "noteworthy topics" — outlet names only, to keep the archive uncluttered.

Verified with a local Hugo build (v0.123.7 extended) that both pages render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2P5UTGE9XboavfZfUMFc8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2P5UTGE9XboavfZfUMFc8)_