### PR TITLE
Add Peloton Buddy article to press links

### DIFF
--- a/blog/content/about/index.md
+++ b/blog/content/about/index.md
@@ -35,6 +35,7 @@ Thanks for stopping by, fam.
 
 * [How Peloton Engineers the World's Largest Live Fitness Events on AWS](https://aws.amazon.com/blogs/industries/how-peloton-engineers-the-worlds-largest-live-fitness-events-on-aws/) - AWS for Industries Blog, Jul 2026
 * [Peloton Behind the Scenes Engineering Stops the Crashes](https://theclipout.com/peloton-behind-the-scenes-engineering/) - The Clip Out, Jul 2026
+* [How Peloton's Engineers Keep Turkey Burn From Crashing: They Test on the Live Platform](https://www.pelobuddy.com/peloton-testing-production/) - Peloton Buddy, Jul 2026
 * [Peloton's engineering team makes the case for test in production](https://www.techtarget.com/searchcloudcomputing/feature/Pelotons-engineering-team-makes-the-case-for-test-in-production) - TechTarget, Jul 2026
 
 ## Talks

--- a/blog/layouts/partials/posts.html
+++ b/blog/layouts/partials/posts.html
@@ -34,7 +34,8 @@
 <strong>recently featured in: </strong>
 <a href="https://aws.amazon.com/blogs/industries/how-peloton-engineers-the-worlds-largest-live-fitness-events-on-aws/">AWS Blog</a> &middot;
 <a href="https://www.techtarget.com/searchcloudcomputing/feature/Pelotons-engineering-team-makes-the-case-for-test-in-production">TechTarget</a> &middot;
-<a href="https://theclipout.com/peloton-behind-the-scenes-engineering/">The Clip Out</a>
+<a href="https://theclipout.com/peloton-behind-the-scenes-engineering/">The Clip Out</a> &middot;
+<a href="https://www.pelobuddy.com/peloton-testing-production/">Peloton Buddy</a>
 
         {{/* Build the homepage entry set: posts not folded into a digest, plus digests and field guides. */}}
         {{ $standalonePosts := where (where site.RegularPages "Type" "posts") "Params.digest" nil }}


### PR DESCRIPTION
Follow-up to #4: adds the fourth press piece covering the test-in-production story.

- [How Peloton's Engineers Keep Turkey Burn From Crashing: They Test on the Live Platform](https://www.pelobuddy.com/peloton-testing-production/) — Peloton Buddy, Jul 24, 2026

Changes:
- **About page**: new entry in the "Featured In" list (after The Clip Out).
- **Homepage**: "Peloton Buddy" appended to the "recently featured in:" strapline.

Verified with a local Hugo build that both pages render the new link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2P5UTGE9XboavfZfUMFc8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2P5UTGE9XboavfZfUMFc8)_