### PR TITLE
Correct outlet name to Pelo Buddy

### DIFF
--- a/blog/content/about/index.md
+++ b/blog/content/about/index.md
@@ -35,7 +35,7 @@ Thanks for stopping by, fam.
 
 * [How Peloton Engineers the World's Largest Live Fitness Events on AWS](https://aws.amazon.com/blogs/industries/how-peloton-engineers-the-worlds-largest-live-fitness-events-on-aws/) - AWS for Industries Blog, Jul 2026
 * [Peloton Behind the Scenes Engineering Stops the Crashes](https://theclipout.com/peloton-behind-the-scenes-engineering/) - The Clip Out, Jul 2026
-* [How Peloton's Engineers Keep Turkey Burn From Crashing: They Test on the Live Platform](https://www.pelobuddy.com/peloton-testing-production/) - Peloton Buddy, Jul 2026
+* [How Peloton's Engineers Keep Turkey Burn From Crashing: They Test on the Live Platform](https://www.pelobuddy.com/peloton-testing-production/) - Pelo Buddy, Jul 2026
 * [Peloton's engineering team makes the case for test in production](https://www.techtarget.com/searchcloudcomputing/feature/Pelotons-engineering-team-makes-the-case-for-test-in-production) - TechTarget, Jul 2026
 
 ## Talks

--- a/blog/layouts/partials/posts.html
+++ b/blog/layouts/partials/posts.html
@@ -35,7 +35,7 @@
 <a href="https://aws.amazon.com/blogs/industries/how-peloton-engineers-the-worlds-largest-live-fitness-events-on-aws/">AWS Blog</a> &middot;
 <a href="https://www.techtarget.com/searchcloudcomputing/feature/Pelotons-engineering-team-makes-the-case-for-test-in-production">TechTarget</a> &middot;
 <a href="https://theclipout.com/peloton-behind-the-scenes-engineering/">The Clip Out</a> &middot;
-<a href="https://www.pelobuddy.com/peloton-testing-production/">Peloton Buddy</a>
+<a href="https://www.pelobuddy.com/peloton-testing-production/">Pelo Buddy</a>
 
         {{/* Build the homepage entry set: posts not folded into a digest, plus digests and field guides. */}}
         {{ $standalonePosts := where (where site.RegularPages "Type" "posts") "Params.digest" nil }}


### PR DESCRIPTION
Fixes the outlet name from "Peloton Buddy" to "Pelo Buddy" (the site's actual branding) in the About page's Featured In list and the homepage strapline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2P5UTGE9XboavfZfUMFc8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2P5UTGE9XboavfZfUMFc8)_